### PR TITLE
fixed path to /dashboard from signup

### DIFF
--- a/public/js/signup.js
+++ b/public/js/signup.js
@@ -13,7 +13,7 @@ async function signupNewUser(event) {
     });
 
     if (response.ok) {
-      document.location.replace("/dasboard");
+      document.location.replace("/dashboard");
     } else {
       alert(response.statusText);
     }


### PR DESCRIPTION
Minor fix - path `/dashboard` from the signup page.